### PR TITLE
removed /api/ prefix from endpoints. use subdomain.

### DIFF
--- a/organization/fetch.ts
+++ b/organization/fetch.ts
@@ -22,4 +22,4 @@ export async function fetch(request: http.Request, context: Context): Promise<ht
 	return result
 }
 
-router.add("GET", "api/organization/:id", fetch)
+router.add("GET", "/organization/:id", fetch)

--- a/organization/list.ts
+++ b/organization/list.ts
@@ -26,4 +26,4 @@ export async function fetch(request: http.Request, context: Context): Promise<ht
 	return result
 }
 
-router.add("GET", "api/organization", fetch)
+router.add("GET", "/organization", fetch)

--- a/user/fetch.ts
+++ b/user/fetch.ts
@@ -34,4 +34,4 @@ export async function fetch(request: http.Request, context: Context): Promise<ht
 	return result
 }
 
-router.add("GET", "api/user/:email", fetch)
+router.add("GET", "/user/:email", fetch)

--- a/user/list.ts
+++ b/user/list.ts
@@ -28,9 +28,8 @@ export async function list(request: http.Request, context: Context): Promise<htt
 								organizationIds.push(organizationId)
 							return organizationIds
 						}, [] as string[])
-						// Object.keys(key.permissions).filter(organizationId => organizationId != "*")
 				  )
 	return result
 }
 
-router.add("GET", "api/user", list)
+router.add("GET", "/user", list)

--- a/version/fetch.ts
+++ b/version/fetch.ts
@@ -15,4 +15,4 @@ export async function fetch(request: http.Request, context: Context): Promise<ht
 
 	return result
 }
-router.add("GET", "api/version", fetch)
+router.add("GET", "/version", fetch)


### PR DESCRIPTION
`api.origin` instead of `origin/api`