### PR TITLE
not defaulting to empty array

### DIFF
--- a/Context/Applications/Storage/Context/Organizations/Organization.ts
+++ b/Context/Applications/Storage/Context/Organizations/Organization.ts
@@ -56,7 +56,7 @@ export namespace Organization {
 							permission => `*.${permission}`
 						).join(" ")
 					),
-					users: [],
+					users: Array.from(new Set(organization.users.map(user => (typeof user == "object" ? user.email : user)))),
 			  }
 	}
 }


### PR DESCRIPTION
The organizations user array was defaulted to an empty array when it was created causing any user without application permissions to be unable to join it with the POST /organization invite and other issues.