### PR TITLE
fix: properly merging permissions on join

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,8 +31,8 @@
 	"editor.detectIndentation": false,
 	"editor.insertSpaces": false,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true,
-		"eslint.autoFixOnSave": true,
+		"source.fixAll.eslint": "explicit",
+		"eslint.autoFixOnSave": "explicit"
 	},
 	"eslint.format.enable": true,
 	"eslint.lintTask.enable": true,

--- a/Context/Users/Storage/Context/Users/User.ts
+++ b/Context/Users/Storage/Context/Users/User.ts
@@ -44,6 +44,7 @@ export namespace User {
 			result = {
 				...source,
 				permissions: {
+					...source.permissions,
 					[context.application]: userwidgets.User.Permissions.merge(
 						source.permissions[context.application] ?? {},
 						patch.permissions


### PR DESCRIPTION
joining another application without this change causes a join request to drop the permissions to the previous applications.